### PR TITLE
use cbor encoding, allow middleware skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![testing](https://github.com/bentranter/sessions/actions/workflows/test.yml/badge.svg)
 [![godoc](https://godoc.org/github.com/bentranter/sessions?status.svg)](https://godoc.org/github.com/bentranter/sessions)
 
-HTTP session cookie management for Go. It allows you to set both data that persists between requests (session data), and data that persists until the next request (flash data).
+Package `sessions` provides HTTP session cookie management for Go. It allows you to set both data that persists between requests (session data), and data that persists until the next request (flash data).
 
 Unlike typical session libraries for Go, sessions uses the request's context for storage within the same request liftime, allowing you to access the session between multiple handlers or HTTP middleware, as well as within test cases that do not use an HTTP server.
 
@@ -80,4 +80,14 @@ http.HandleFunc("/reset", func(w http.ResponseWriter, r *http.Request) {
     session.Reset(w, r)
     http.Redirect(w, r, "/", http.StatusFound)
 })
+```
+
+### Using with [`templ`](https://github.com/a-h/templ)
+
+```templ
+templ FlashComponent() {
+	for key, val := range session.FlashesCtx(ctx) {
+		<div>{ key }: { fmt.Sprintf("%v", val) }</div>
+	}
+}
 ```

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,7 @@ module github.com/bentranter/sessions
 go 1.21.1
 
 require github.com/gorilla/securecookie v1.1.2
+
+require github.com/fxamacker/cbor/v2 v2.7.0
+
+require github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
+github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
+github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=


### PR DESCRIPTION
Updates the cookie serializer to use the [CBOR codec](https://github.com/fxamacker/cbor) for encoding the cookie data, as well as adds an option to skip TemplMiddleware for certain paths.

In testing, the CBOR encoding is 3.5x faster than encoding/gob. It also doesn't require the struct data to be registered for encoding, which is an additional UX improvement over gob.